### PR TITLE
feat(cache): generate cache needed for ingest

### DIFF
--- a/invenio_analytics_importer/cache.py
+++ b/invenio_analytics_importer/cache.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-analytics-importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+from invenio_db import db
+from invenio_rdm_records.records import RDMRecord
+from invenio_search import current_search_client
+from invenio_search.engine import dsl
+from sqlalchemy import select
+
+from invenio_analytics_importer.convert import iter_to_entries_of_download_analytics  # noqa
+
+
+def scan_records(record_cls, pids):
+    """Retrieve SE record."""
+    s = dsl.Search(
+        using=current_search_client,
+        index=record_cls.index.search_alias
+    )
+
+    s = s.filter({"terms": {"id": pids}})
+
+    response = s.scan()
+
+    return response
+
+
+class Cache:
+    """Cache of system info."""
+
+    def __init__(self):
+        """Constructor."""
+        self._data = []
+        self._pid_record_and_file_key_to_file_id = {}
+        self._pid_record_to_bucket_id = {}
+        self._file_id_to_size = {}
+        self._pid_record_to_pid_parent = {}
+
+    def get_file_id(self, pid_of_record, file_key):
+        """Get file id."""
+        return self._pid_record_and_file_key_to_file_id[(pid_of_record, file_key)]  # noqa
+
+    def set_file_id(self, pid_of_record, file_key, file_id):
+        """Set file id."""
+        self._pid_record_and_file_key_to_file_id[(pid_of_record, file_key)] = file_id  # noqa
+
+    def get_bucket_id(self, pid_of_record):
+        """Get bucket id associated with record."""
+        return self._pid_record_to_bucket_id[pid_of_record]
+
+    def set_bucket_id(self, pid_of_record, bucket_id):
+        """Set bucket id associated with record."""
+        self._pid_record_to_bucket_id[pid_of_record] = str(bucket_id)
+
+    def get_size(self, file_id):
+        """Get size in bytes of file."""
+        return self._file_id_to_size.get(file_id, 0)
+
+    def set_size(self, file_id, size):
+        """Set size in bytes of file."""
+        self._file_id_to_size[file_id] = size
+
+    def get_parent_pid(self, pid_of_record):
+        """Get pid of parent of record."""
+        return self._pid_record_to_pid_parent[pid_of_record]
+
+    def set_parent_pid(self, pid_of_record, pid_of_parent):
+        """Set pid of parent of record."""
+        self._pid_record_to_pid_parent[pid_of_record] = pid_of_parent
+
+
+def generate_cache(filepaths):
+    """Generate cache."""
+    cache = Cache()
+
+    pids_set = set()
+    for entry in iter_to_entries_of_download_analytics(filepaths):
+        pids_set.add(entry.pid)
+
+    record_cls = RDMRecord
+    uuid_to_pid = {}
+
+    # Get and populate file_ids, size, and parent_id
+    results = scan_records(record_cls, list(pids_set))
+    for hit in results:
+        pid = hit["id"]
+        pid_of_parent = hit["parent"]["id"]
+        uuid = hit["uuid"]
+
+        cache.set_parent_pid(pid, pid_of_parent)
+        uuid_to_pid[uuid] = pid
+
+        entries = hit.get("files", {}).get("entries", [])
+        for e in entries:
+            key = e["key"]
+            file_id = e["file_id"]
+            size = e["size"]
+
+            cache.set_file_id(pid, key, file_id)
+            cache.set_size(file_id, size)
+
+    # Get and populate bucket id
+    stmt = (
+        select(
+            record_cls.model_cls.id,
+            record_cls.model_cls.bucket_id,
+        )
+        .where(record_cls.model_cls.id.in_(list(uuid_to_pid.keys())))
+    )
+
+    for uuid_of_record, bucket_id in db.session.execute(stmt):
+        pid = uuid_to_pid[str(uuid_of_record)]
+        cache.set_bucket_id(pid, bucket_id)
+
+    return cache

--- a/invenio_analytics_importer/convert.py
+++ b/invenio_analytics_importer/convert.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-analytics-importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import dataclasses
+import re
+
+from .read import iter_day_analytics_from_filepaths
+
+
+@dataclasses.dataclass
+class EntryOfDownloadFromAnalytics:
+    """Intermediate representation."""
+
+    year_month_day: str  # keeping it simple for now
+    pid: str
+    file_key: str
+    visits: int
+    views: int
+
+    @classmethod
+    def create(cls, year_month_day, analytics_raw):
+        """Create Entry from raw analytics."""
+        label = analytics_raw.get("label", "")
+
+        # extract "3s45v-k5m55" from ".../records/3s45v-k5m55[/...]"
+        regex_pid = re.compile(r"/records/([^/]*)(?:/|$)")
+        pid = regex_pid.search(label).group(1)
+
+        # extract file key
+        regex_key = re.compile(r"/files/([^?]*)\?download=1")
+        file_key = regex_key.search(label).group(1)
+
+        return EntryOfDownloadFromAnalytics(
+            year_month_day=year_month_day,
+            pid=pid,
+            file_key=file_key,
+            visits=analytics_raw.get("nb_visits", 0),
+            views=analytics_raw.get("nb_hits", 0),
+        )
+
+
+def iter_to_entries_of_download_analytics(filepaths):
+    """Iterable of download actions as fully formed input to search engine."""
+    for year_month_day, raw_analytics in iter_day_analytics_from_filepaths(filepaths):
+        yield EntryOfDownloadFromAnalytics.create(year_month_day, raw_analytics)

--- a/invenio_analytics_importer/read.py
+++ b/invenio_analytics_importer/read.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-analytics-importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import json
+
+
+def read_json(filepath):
+    """Read json filepath."""
+    with open(filepath) as f:
+        return json.load(f)
+
+
+def iter_day_analytics_from_filepaths(filepaths):
+    """Iterate (YYYY-MM-DD, analytic) from all filepaths."""
+    for fp in filepaths:
+        analytics_from_fp = read_json(fp)
+        for year_month_day, raw_analytics_list in analytics_from_fp.items():
+            for raw_analytics in raw_analytics_list:
+                yield (year_month_day, raw_analytics)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-analytics-importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import json
+
+from invenio_analytics_importer.cache import generate_cache
+
+
+def write_json(filepath, content):
+    """Write json filepath."""
+    with open(filepath, "w") as f:
+        json.dump(content, f)
+    return filepath
+
+
+def test_generate_cache(running_app, record_factory, tmp_path):
+    r1 = record_factory.create_record(
+        filenames=["PNB-7-75.txt", "PNB 7 76.txt"]
+    )
+    r2 = record_factory.create_record(filenames=["coffee.assess.nobmi.txt"])
+    r2.index.refresh() # r2 and r1 share same index
+
+    fp1 = write_json(
+        tmp_path / "downloads_2024-08.json",
+        {
+            "2024-08-30": [
+                {
+                    "label": f"prism.northwestern.edu/records/{r1.pid.pid_value}/files/PNB-7-75.txt?download=1",
+                    "nb_hits": 1,
+                    "nb_uniq_visitors": 1,
+                    "nb_visits": 1,
+                    "sum_time_spent": 0,
+                },
+                {
+                    "label": f"prism.northwestern.edu/records/{r1.pid.pid_value}/files/PNB 7 76.txt?download=1",
+                    "nb_hits": 1,
+                    "nb_uniq_visitors": 1,
+                    "nb_visits": 1,
+                    "sum_time_spent": 0,
+                },
+            ]
+        },
+    )
+    fp2 = write_json(
+        tmp_path / "downloads_2024-09.json",
+        {
+            "2024-09-01": [
+                {
+                    "label": f"prism.northwestern.edu/records/{r1.pid.pid_value}/files/PNB 7 76.txt?download=1",
+                    "nb_hits": 1,
+                    "nb_uniq_visitors": 1,
+                    "nb_visits": 1,
+                    "sum_time_spent": 0,
+                },
+                {
+                    "label": f"prism.northwestern.edu/records/{r2.pid.pid_value}/files/coffee.assess.nobmi.txt?download=1",
+                    "nb_hits": 3,
+                    "nb_uniq_visitors": 1,
+                    "nb_visits": 2,
+                    "sum_time_spent": 0,
+                },
+            ]
+        }
+    )
+
+    cache = generate_cache([fp1, fp2])
+
+    file_id = cache.get_file_id(r1.pid.pid_value, "PNB 7 76.txt")
+    assert str(r1.files["PNB 7 76.txt"].file.file_model.id) == file_id
+    parent_pid = cache.get_parent_pid(r1.pid.pid_value)
+    assert str(r1.parent.pid.pid_value) == parent_pid
+    size = cache.get_size(file_id)
+    assert r1.files['PNB 7 76.txt'].file.file_model.size == size
+    bucket_id = cache.get_bucket_id(r1.pid.pid_value)
+    assert str(r1.bucket_id) == bucket_id

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Northwestern University.
+#
+# invenio-analytics-importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+from invenio_analytics_importer.convert import EntryOfDownloadFromAnalytics
+import pytest
+
+
+@pytest.fixture
+def entry_analytics_raw():
+    """Raw Matamo analytics entry."""
+    return (
+        "2024-08-30",
+        {
+            "label": "prism.northwestern.edu/records/3s45v-k5m55/files/coffee.assess.bmi.gz?download=1",
+            "nb_hits": 5,
+            "nb_uniq_visitors": 2,
+            "nb_visits": 3,
+            "sum_time_spent": 0,
+        },
+    )
+
+
+def test_entry_create(entry_analytics_raw):
+    entry = EntryOfDownloadFromAnalytics.create(*entry_analytics_raw)
+
+    assert entry.pid == "3s45v-k5m55"
+    assert entry.file_key == "coffee.assess.bmi.gz"
+    assert entry.visits == 3
+    assert entry.views == 5
+    assert entry.year_month_day == "2024-08-30"


### PR DESCRIPTION
I divided up the work I was doing into smaller pieces, but it may not highlight the overall architecture so I will do so here:

We are trying to import legacy Matomo analytics reports into our InvenioRDM instance. This code could be used by any InvenioRDM instance to do so.

There are 4 parts to this:
- Downloading analytics from Matomoto (perhaps other sources eventually)
- Converting those into practical data structures **partly in this PR**
- Generating a cache of system information needed when ingesting analytics into instance's statistics (for performance and responsibility reasons) **<--- this PR**
- Ingesting analytics into instance's statistics system

